### PR TITLE
Fix deployment YAML step name quoting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
           mkdir -p dist/content
           cp -r public/content/* dist/content/
 
-      - name: 🔍 Debug: List public directory contents before copy
+      - name: "🔍 Debug: List public directory contents before copy"
         run: |
           echo "Listing public/ directory:"
           ls -F public/


### PR DESCRIPTION
## Summary
- quote the step name with a colon in `deploy.yml`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855242d5c68832fa08ab072037cf487